### PR TITLE
unistd.h inclusion

### DIFF
--- a/PosixSocketClient/src/EPosixClientSocketPlatform.h
+++ b/PosixSocketClient/src/EPosixClientSocketPlatform.h
@@ -54,6 +54,7 @@
 	#include <sys/select.h>
 	#include <netdb.h>
 	#include <fcntl.h>
+	#include <unistd.h>
 
 	namespace IB {
 	// helpers


### PR DESCRIPTION
necessary for `close()`
