### PR TITLE
merge feat/nosockopt

### DIFF
--- a/PosixSocketClient/src/EPosixClientSocket.cpp
+++ b/PosixSocketClient/src/EPosixClientSocket.cpp
@@ -280,7 +280,7 @@ int EPosixClientSocket::fd() const
 }
 
 
-int EPosixClientSocket::handshake(int socket, int clientId)
+int EPosixClientSocket::prepareHandshake(int socket, int clientId)
 {
 	if (this->m_fd > 0) {
 		/* don't matter what SOCKET is we use the one we know about */
@@ -298,6 +298,9 @@ int EPosixClientSocket::handshake(int socket, int clientId)
 
 int EPosixClientSocket::handshake(void)
 {
+/* if everything goes ok, handshake() will return 0,
+ * on error -1 is returned, and
+ * once the handshake is finished 1 is returned. */
 	if (this->m_fd < 0) {
 		/* do fuckall */
 		errno = EBADF;
@@ -324,13 +327,14 @@ int EPosixClientSocket::handshake(void)
 			return -1;
 		}
 		this->hnd_shk_state = HND_SHK_ST_RCVD_CONNACK;
-		break;
+		/*@fallthrough@*/
 
 	case HND_SHK_ST_RCVD_CONNACK:
-		;
+		/* handshake succeeded */
+		return 1;
 	default:
 	case HND_SHK_ST_UNK:
-		break;
+		return -1;
 	}
 
 	// successfully connected
@@ -345,10 +349,6 @@ int EPosixClientSocket::wavegoodbye(void)
 	return 0;
 }
 
-bool EPosixClientSocket::handshakeComplete()
-{
-	return this->hnd_shk_state == HND_SHK_ST_RCVD_CONNACK;
-}
 
 int EPosixClientSocket::send(const char* buf, size_t sz)
 {

--- a/PosixSocketClient/src/EPosixClientSocket.h
+++ b/PosixSocketClient/src/EPosixClientSocket.h
@@ -25,11 +25,9 @@ public:
 
 	/* Here's the expert API that just performs protocol actions on
 	 * a socket established and maintained elsewhere. */
-	int handshake(int socket, int clientId = 0);
+	int prepareHandshake(int socket, int clientId = 0);
 	int handshake(void);
 	int wavegoodbye(void);
-
-	bool handshakeComplete();
 
 private:
 


### PR DESCRIPTION
This feature set provides an alternative way to get the tws connection started.  The essentials are 3 functions:
- `prepareHandshake()` used to notify the `EPosixClientSocket` object of the socket to be used and the client id
- `handshake()` performs one step of handshaking, i.e. the initial set up between TWS and the client
- `wavegoodbye()` performs the goodbye procedure at the end, i.e. any deinitialising communication between TWS and the client

We say it's an alternative because it replaces the traditional `eConnect()` and `eDisconnect()` routines, both of which operate on a socket created by the `EPosixClientSocket` object and hence out of user control (e.g. `setsockopt()` calls might let the internal operations go funky).
