### PR TITLE
Update readme to reflect the need for libtool package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This twsapi is almost identical to the original IB C++ Posix API. It contains
 several bugfixes, usage improvements and it's using the autotools build system.
 For more details read "Changes of original IB API" below.
 
-The project homepage (bugtracker, latest git repo) is hosted on github
- https://github.com/rudimeier/twsapi
-Released source tarballs download here
- https://bitbucket.org/rudimeier/twsapi/downloads
-Binary rpms for various Linux distros here
- http://software.opensuse.org/download.html?project=home:rudi_m&package=twsapi
+The project homepage (bugtracker, latest git repo) is hosted on [github]
+ (https://github.com/rudimeier/twsapi)
+Released source tarballs download [here]
+ (https://bitbucket.org/rudimeier/twsapi/downloads)
+Binary rpms for various Linux distros [here]
+ (http://software.opensuse.org/download.html?project=home:rudi_m&package=twsapi)
 
 
 
@@ -25,11 +25,13 @@ Installation
  Windows/Cygwin. Native Windows/Mingw is also supported.
 
  When building from git checkout you need both autotools and libtool.  Also, Don't forget to
- type "autoreconf -vfi" first.
+ type `autoreconf -vfi` first.
 
+```bash
  ./configure
  make
  make install
+```
 
 
 
@@ -55,11 +57,11 @@ Changes of original IB API
 Here I point out some of the most important things about our modified TWS API.
 (This documentation may not be entirely complete.)
 
-Improvements:
- - Comfortable autotools build chain and pkg-config support to make developers
+__Improvements:__
+ - Comfortable `autotools` build chain and `pkg-config` support to make developers
    happy.
  - Generally the socket error handling is stable and reliable now. Error message
-   callbacks with code SOCKET_EXCEPTION are using standard message strings
+   callbacks with code `SOCKET_EXCEPTION` are using standard message strings
    (errno/strerror).
  - Never throwing nor catching any Exceptions.
  - Using non-blocking sockets with well defined connection timeout.
@@ -68,55 +70,55 @@ Improvements:
  - Source compatibility between API updates.
 
 
-Below some details about the improved reliablity of the API interface functions
+Below are some details about the improved reliability of the API interface functions
 and callbacks.
 
-eConnect():
+__eConnect():__
  1. It's blocking and returns either connected or disconnected.
  2. It may callback informative error messages only. No more checking of
     regular messages.
  3. If any callback is fired then state will still be  "disconnected".
     Return false in this case. There are no "positive callbacks".
- 4. There can be multiple callbacks, for example "UPDATE_TWS" and then
-    "CONNECT_FAIL" but 2. and 3. are always in place! The client programmer
+ 4. There can be multiple callbacks, for example `UPDATE_TWS` and then
+    `CONNECT_FAIL` but 2. and 3. are always in place! The client programmer
     does not need to do any cleanup actions on these callbacks.
- 5. Before returning false CONNECT_FAIL with descriptive message will be fired
+ 5. Before returning false `CONNECT_FAIL` with descriptive message will be fired
     fore sure.
 
 
-onReceive():
- 1. Any callback (except connectionClosed()) will be fired in state connected,
+__onReceive():__
+ 1. Any callback (except `connectionClosed()`) will be fired in state connected,
     even if we are going to be disconnected.
- 2. Before connectionClosed() is fired we will get a "SOCKET_EXCEPTION"
-    callback still in state conneted.
+ 2. Before `connectionClosed()` is fired we will get a `SOCKET_EXCEPTION`
+    callback still in state connected.
 
 
-all other req*() functions:
- 1. If called while disconneted then it sends a NOT_CONNECTED callback (we
+__all other req*() functions:__
+ 1. If called while disconnected then it sends a `NOT_CONNECTED` callback (we
     could have known before).
- 2. On error it sends a SOCKET_EXCEPTION (still in state connected) and
+ 2. On error it sends a `SOCKET_EXCEPTION` (still in state connected) and
     then connectionClosed() (already disconnected state).
- 3. Another possible callback is UPDATE_TWS (does not disconnect us).
+ 3. Another possible callback is `UPDATE_TWS` (does not disconnect us).
 
 
 
-Thus we know about callbacks:
- 1. Within connectionClosed() we are disconnected for sure.
- 2. Within error() we could be disconneted only if code is CONNECT_FAIL,
-    UPDATE_TWS or NOT_CONNECTED.
+__Thus we know about callbacks:__
+ 1. Within `connectionClosed()` we are disconnected for sure.
+ 2. Within `error()` we could be disconnected only if code is `CONNECT_FAIL`,
+    `UPDATE_TWS` or `NOT_CONNECTED`.
  3. In any other case callbacks will be received in state connected.
 
 
-TODO: In oppsite to the statements above SOCKET_EXCEPTION may still be fired in
-      state connected if onReceive() or onSend() are called while disconnected
+__TODO__: In opposite to the statements above `SOCKET_EXCEPTION` may still be fired in
+      state connected if `onReceive()` or `onSend()` are called while disconnected
       (we could have known before). To be safe we could return early and send
-      NOT_CONNECTED.
+      `NOT_CONNECTED`.
 
 
-API internal implementation notes:
+_API internal implementation notes:_
 
-bufferedRead()
- 1. Behaves like ::recv() regarding errno and return value:
+__bufferedRead()__
+ 1. Behaves like `::recv()` regarding errno and return value:
       -1: error, errno set
        0: EOF, disconnectd
       >0: success
@@ -139,4 +141,3 @@ Contact Information
 
   If you have questions, bug reports, patches etc., contact
   Ruediger Meier <sweet_f_a@gmx.de> (in English or German).
-


### PR DESCRIPTION
Here is the error I got originally:

``` bash
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoconf --force
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:12: installing './compile'
configure.ac:8: installing './install-sh'
configure.ac:8: installing './missing'
PosixSocketClient/Makefile.am:6: error: Libtool library used but 'LIBTOOL' is undefined
PosixSocketClient/Makefile.am:6:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
PosixSocketClient/Makefile.am:6:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
PosixSocketClient/Makefile.am:6:   If 'LT_INIT' is in 'configure.ac', make sure
PosixSocketClient/Makefile.am:6:   its definition is in aclocal's search path.
PosixSocketClient/Makefile.am:8: warning: source file 'src/EClientSocketBase.cpp' is in a subdirectory,
PosixSocketClient/Makefile.am:8: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
PosixSocketClient/Makefile.am:8: warning: source file 'src/EPosixClientSocket.cpp' is in a subdirectory,
PosixSocketClient/Makefile.am:8: but option 'subdir-objects' is disabled
PosixSocketClient/Makefile.am: installing './depcomp'
autoreconf: automake failed with exit status: 1
```
